### PR TITLE
Limit globally addable types

### DIFF
--- a/onegov/municipality/profiles/default/types/Plone_Site.xml
+++ b/onegov/municipality/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="Plone Site"
+        meta_type="Factory-based Type Information with dynamic views">
+
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types" purge="True">
+        <element value="ftw.topics.TopicTree"/>
+        <element value="ContentPage" />
+        <element value="Folder" />
+    </property>
+
+</object>


### PR DESCRIPTION
I think we should limit the addable types on the Plone Site root to the important ones:
![bildschirmfoto 2013-08-05 um 17 05 12](https://f.cloud.github.com/assets/7469/910788/7607e534-fde0-11e2-94b0-9e250c1da881.png)

Which ones should be addable?
