### PR TITLE
Configure sharing page: display "Editor" and "Administrator" roles only.

### DIFF
--- a/onegov/municipality/lawgiver.zcml
+++ b/onegov/municipality/lawgiver.zcml
@@ -6,14 +6,6 @@
 
     <include package="ftw.lawgiver" file="meta.zcml" />
 
-    <!-- In the onegov-simple-workflow we don't use some Plone standard
-         Roles, so we deactivate them. -->
-    <lawgiver:map_permissions
-        action_group="delegate plone roles"
-        permissions="Sharing page: Delegate Reader role,
-                     Sharing page: Delegate Contributor role,
-                     Sharing page: Delegate Reviewer role"
-        workflow="onegov-simple-workflow"
-        />
+    <lawgiver:role name="Site Administrator" />
 
 </configure>

--- a/onegov/municipality/locales/de/LC_MESSAGES/plone.po
+++ b/onegov/municipality/locales/de/LC_MESSAGES/plone.po
@@ -12,10 +12,20 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone\n"
+
+msgid "onegov-simple-workflow--ROLE--Anonymous"
+msgstr "Besucher"
+
+msgid "onegov-simple-workflow--ROLE--Editor"
+msgstr "Redaktor"
+
+msgid "onegov-simple-workflow--ROLE--Manager"
+msgstr "System Administrator"
+
+msgid "onegov-simple-workflow--ROLE--Site Administrator"
+msgstr "Administrator"
 
 msgid "onegov-simple-workflow--STATUS--draft"
 msgstr "Entwurf"

--- a/onegov/municipality/locales/en/LC_MESSAGES/plone.po
+++ b/onegov/municipality/locales/en/LC_MESSAGES/plone.po
@@ -12,10 +12,20 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone\n"
+
+msgid "onegov-simple-workflow--ROLE--Anonymous"
+msgstr "Visitor"
+
+msgid "onegov-simple-workflow--ROLE--Editor"
+msgstr "Editor"
+
+msgid "onegov-simple-workflow--ROLE--Manager"
+msgstr "System Administrator"
+
+msgid "onegov-simple-workflow--ROLE--Site Administrator"
+msgstr "Administrator"
 
 msgid "onegov-simple-workflow--STATUS--draft"
 msgstr "Draft"

--- a/onegov/municipality/locales/plone.pot
+++ b/onegov/municipality/locales/plone.pot
@@ -17,6 +17,18 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone\n"
 
+msgid "onegov-simple-workflow--ROLE--Anonymous"
+msgstr ""
+
+msgid "onegov-simple-workflow--ROLE--Editor"
+msgstr ""
+
+msgid "onegov-simple-workflow--ROLE--Manager"
+msgstr ""
+
+msgid "onegov-simple-workflow--ROLE--Site Administrator"
+msgstr ""
+
 msgid "onegov-simple-workflow--STATUS--draft"
 msgstr ""
 

--- a/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/definition.xml
+++ b/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/definition.xml
@@ -40,6 +40,7 @@
   <permission>Sharing page: Delegate Editor role</permission>
   <permission>Sharing page: Delegate Reader role</permission>
   <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate Site Administrator role</permission>
   <permission>Sharing page: Delegate roles</permission>
   <permission>Take ownership</permission>
   <permission>View</permission>
@@ -244,6 +245,10 @@
     </permission-map>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Site Administrator role" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -545,6 +550,10 @@
     </permission-map>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Site Administrator role" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>

--- a/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/specification.txt
+++ b/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/specification.txt
@@ -9,6 +9,11 @@ Role Mapping:
   System Administrator => Manager
 
 
+Visible Roles:
+  Editor
+  Administrator
+
+
 General:
   An Editor can always view any content.
   An Editor can always view inactive objects.

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,8 +3,10 @@ extends = http://plonesource.org/sources.cfg
 extensions += mr.developer
 
 auto-checkout =
+    ftw.builder
     ftw.contentpage
     ftw.footer
+    ftw.lawgiver
     ftw.mobilenavigation
     plonetheme.onegov
     seantis.dir.events


### PR DESCRIPTION
- Register "Site Administrator" as "Administrator" for the sharing page
- Limit the sharing page to display the "Editor" and "Administrator" roles
- Translate the roles to German

based on 4teamwork/ftw.lawgiver/pull/23, remove lawgiver branch from `sources.cfg` before merging
