### PR TITLE
Fixed order of packages in inflator.

### DIFF
--- a/onegov/municipality/inflator.zcml
+++ b/onegov/municipality/inflator.zcml
@@ -14,8 +14,8 @@
         title="OneGov Box Municipality (empty)"
         description="Setup an empty OneGov Box for development"
         profiles="ftw.inflator:setup-language
-                  plonetheme.onegov:default
-                  onegov.municipality:default"
+                  onegov.municipality:default
+                  plonetheme.onegov:default"
         standard="True"
         />
 
@@ -23,10 +23,10 @@
         title="OneGov Box Municipality with example content"
         description="Setup a OneGov Box for a municipality with example content."
         profiles="ftw.inflator:setup-language
-                  plonetheme.onegov:default
                   onegov.municipality:default
                   onegov.municipality:init-topics
-                  onegov.municipality:init-content"
+                  onegov.municipality:init-content
+                  plonetheme.onegov:default"
         standard="True"
         />
 


### PR DESCRIPTION
If plonetheme.onegov isn't installed as last product the order in cssregistry is not right. And the theme will be overwritten by the addon packages.
@jone @maethu 
