### PR TITLE
Workflow: Let administrators manage the footer.

### DIFF
--- a/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/definition.xml
+++ b/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/definition.xml
@@ -57,6 +57,7 @@
   <permission>ftw.contentpage: Edit teaser image on News</permission>
   <permission>ftw.file: Add File</permission>
   <permission>ftw.file: Edit advanced fields</permission>
+  <permission>ftw.footer: Manage Footer</permission>
   <permission>ftw.slider: Add Container</permission>
   <permission>ftw.slider: Add Pane</permission>
   <permission>ftw.subsite: Add Subsite</permission>
@@ -325,6 +326,10 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="ftw.file: Edit advanced fields" acquired="False"/>
+    <permission-map name="ftw.footer: Manage Footer" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <permission-map name="ftw.slider: Add Container" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
@@ -641,6 +646,10 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="ftw.file: Edit advanced fields" acquired="False"/>
+    <permission-map name="ftw.footer: Manage Footer" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
     <permission-map name="ftw.slider: Add Container" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>

--- a/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/specification.txt
+++ b/onegov/municipality/profiles/default/workflows/onegov-simple-workflow/specification.txt
@@ -24,6 +24,7 @@ General:
   An Administrator can always perform the same actions as an Editor.
   An Administrator can always manage security.
   An Administrator can always manage portlets.
+  An Administrator can always manage footer.
 
   A System Administrator can always perform the same actions as an Administrator.
 


### PR DESCRIPTION
Administrators should be able to manage the footer.
The footer permission is now mapped to the action group `manage footer`, which did break the tests..

@maethu please take a look
